### PR TITLE
Verify JSON request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,9 @@
 
 name: PyPI release
 
-on: [release]
+on:
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
* Verify appropriate HTTP Content-Type header
* Verify body is parseable as JSON

I believe this should fix #15 

If nothing else, we should see a fewer spurious 500 errors related to http requests we're not capable of handling :-)