### PR TITLE
Verify X-GitHub-Event Header

### DIFF
--- a/flask_githubapp/core.py
+++ b/flask_githubapp/core.py
@@ -184,7 +184,15 @@ class GitHubApp(object):
                                            400)
             abort(error_response)
 
-        event = request.headers['X-GitHub-Event']
+        event_header = 'X-GitHub-Event'
+        if event_header not in request.headers:
+            error_message = 'Missing X-GitHub-Event HTTP header.'
+            LOG.error(error_message)
+            error_response = make_response(jsonify(status='ERROR', description=error_message),
+                                           400)
+            abort(error_response)
+
+        event = request.headers[event_header]
         action = request.json.get('action')
 
         if current_app.config['GITHUBAPP_SECRET'] is not False:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -276,3 +276,19 @@ def test_invalid_json_body_returns_error(github_app):
             'status': 'ERROR',
             'description': 'Invalid HTTP body (must be JSON).'
         }
+
+def test_missing_event_header_returns_error(github_app):
+    """HTTP request must havea X-GitHub-Event header"""
+    github_app.config['GITHUBAPP_SECRET'] = False
+    with github_app.test_client() as client:
+        resp = client.post('/',
+                           data=json.dumps({'installation': {'id': 2},
+                                            'action': 'bar'}),
+                           headers={
+                              'Content-Type': 'application/json'
+                           })
+        assert resp.status_code == 400
+        assert resp.json == {
+            'status': 'ERROR',
+            'description': 'Missing X-GitHub-Event HTTP header.'
+        }


### PR DESCRIPTION
Fixes #24 (well, should hopefully make it much more clear to users what the error is).

* Previously, this would throw a KeyError if the header was missing. This thrown error would get caught
  and returned to the caller as a 500 error without any context. It would also leave a potentially
  confusing traceback in the application logs.
* Now, we first check if the header is present and if it's missing we alert the caller via a 400
  response with appropriate description as well as leaving a much more relevant error log event.