### PR TITLE
change context check in payload()

### DIFF
--- a/flask_githubapp/core.py
+++ b/flask_githubapp/core.py
@@ -107,7 +107,7 @@ class GitHubApp(object):
     @property
     def payload(self):
         """GitHub hook payload"""
-        if request and request.json and 'installation' in request.json:
+        if request and request.json and request.headers.get('X-GitHub-Hook-Installation-Target-ID'):
             return request.json
 
         raise RuntimeError('Payload is only available in the context of a GitHub hook request')


### PR DESCRIPTION
👋 `payload()` method had a context check where it was searching for `installation` in the webhook payload delivered. This was failing on all webhook deliveries because the latest payloads do not include installation information in the payload itself. Switched the check to checking to a header `X-GitHub-Hook-Installation-Target-ID` sent with all webhooks.

Possibly want to extend to check for additional headers and validate the values in those headers

```
X-GitHub-Hook-ID: XXXXXXX
**X-GitHub-Hook-Installation-Target-ID: XXXXXXX**
X-GitHub-Hook-Installation-Target-Type: organization
```